### PR TITLE
Fix LC pr#955

### DIFF
--- a/libs/vertexai/tests/integration_tests/test_llms.py
+++ b/libs/vertexai/tests/integration_tests/test_llms.py
@@ -95,7 +95,7 @@ def test_vertex_call_count_tokens() -> None:
 def test_structured_output_schema_json():
     model = VertexAI(
         rate_limiter=rate_limiter,
-        model_name="gemini-1.5-pro-001",
+        model_name="gemini-2.0-flash-001",
         response_mime_type="application/json",
         response_schema={
             "type": "array",


### PR DESCRIPTION
Fixes tests for https://github.com/langchain-ai/langchain-google/pull/955: `test_structured_output_schema_json`.

I can only get to know the remaining test failures once this is completed.